### PR TITLE
SMP: Reject pairing if public_key.x match

### DIFF
--- a/stack/smp/smp_act.cc
+++ b/stack/smp/smp_act.cc
@@ -695,8 +695,7 @@ void smp_process_pairing_public_key(tSMP_CB* p_cb, tSMP_INT_DATA* p_data) {
   memcpy(pt.x, p_cb->peer_publ_key.x, BT_OCTET32_LEN);
   memcpy(pt.y, p_cb->peer_publ_key.y, BT_OCTET32_LEN);
 
-  if (!memcmp(p_cb->peer_publ_key.x, p_cb->loc_publ_key.x, BT_OCTET32_LEN) &&
-      !memcmp(p_cb->peer_publ_key.y, p_cb->loc_publ_key.y, BT_OCTET32_LEN)) {
+  if (!memcmp(p_cb->peer_publ_key.x, p_cb->loc_publ_key.x, BT_OCTET32_LEN)) {
     android_errorWriteLog(0x534e4554, "174886838");
     SMP_TRACE_WARNING("Remote and local public keys can't match");
     tSMP_INT_DATA smp;


### PR DESCRIPTION
Bug: 189329824
Test: POC
Test: pair an LE device
Change-Id: If6d8a72075f0cf657cadfab033cacffeb22868cb
Tag: #security
(cherry picked from commit 9fbf77d1a81b3a1e09d4efa96070a568431e844d)